### PR TITLE
feat(course-slider): implement course slider section with Swiper 

### DIFF
--- a/app/(site)/courses/page.tsx
+++ b/app/(site)/courses/page.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+function CoursesPage() {
+    return (
+        <h1 className="w-full h-screen flex justify-center items-center">
+            Courses Page
+        </h1>
+    );
+}
+
+export default CoursesPage;

--- a/components/atoms/Button.tsx
+++ b/components/atoms/Button.tsx
@@ -12,7 +12,7 @@ function Button({
     return (
         <button
             className={cn(
-                "rounded-full cursor-pointer",
+                "rounded-full cursor-pointer ",
                 className,
                 VARIANTS_STYLE[variant],
                 SIZE_STYLE[size],

--- a/components/organisms/Cards/CourseCard.tsx
+++ b/components/organisms/Cards/CourseCard.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import {CourseCardHero, CourseCardList, CourseCardSlide} from "@/components/organisms/Cards/index";
-import {CourseType} from "@/types/hero-section";
+import {CourseType} from "@/types/course";
 
 function CourseCard(course: CourseType) {
     switch (course.variant) {

--- a/components/organisms/Cards/CourseCardHero.tsx
+++ b/components/organisms/Cards/CourseCardHero.tsx
@@ -3,7 +3,7 @@ import {CourseDeadline} from "@/components/organisms/Countdown";
 import Image from "next/image";
 import {FeatureItem} from "@/components/molecules";
 import {Button, StatusBadge} from "@/components/atoms";
-import {CourseType} from "@/types/hero-section";
+import {CourseType} from "@/types/course";
 
 function CourseCardHero({
                             id,

--- a/components/organisms/Cards/CourseCardList.tsx
+++ b/components/organisms/Cards/CourseCardList.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import Image from "next/image";
 import {FeatureItem} from "@/components/molecules";
 import {StatusBadge} from "@/components/atoms";
-import {CourseType} from "@/types/hero-section";
+import {CourseType} from "@/types/course";
 
 function CourseCardList({id, title, description, status, image, className}: CourseType) {
     return (

--- a/components/organisms/Cards/CourseCardSlide.tsx
+++ b/components/organisms/Cards/CourseCardSlide.tsx
@@ -2,23 +2,26 @@ import Link from "next/link";
 import Image from "next/image";
 import {FeatureItem} from "@/components/molecules";
 import {StatusBadge} from "@/components/atoms";
-import {CourseType} from "@/types/hero-section";
-
+import {CourseType} from "@/types/course";
 
 function CourseCardSlide({id, title, description, status, image, className}: CourseType) {
     return (
-        <Link href={`/courses/${id}`} className={`bg-white shadow-md rounded-lg p-4 flex flex-col ${className}`}>
-            <div className="flex items-center gap-4">
-                <Image src={image} alt={title} width={100} height={100} className="object-contain"/>
+        <Link
+            href={`/courses/${id}`}
+            className={`flex shrink-0 w-[264px] md:w-[548px] bg-white shadow rounded-lg p-2 md:p-6 mx-4 ${className}`}
+        >
+            <div className="flex items-center md:gap-8">
                 <div className="flex flex-col gap-2">
-                    <h2 className="text-lg font-semibold">{title}</h2>
-                    <p className="text-sm text-gray-600">{description}</p>
-                    <div className="flex gap-2">
+                    <h2 className="font-medium md:font-semibold text-sm md:text-2xl">{title}</h2>
+                    <p className="font-normal text-[12px] md:text-[16px] text-gray-600">{description}</p>
+                    <div className="flex gap-2 mt-4 mb-2">
                         <FeatureItem icon="/icon/course/clock.svg" text="۶ ماه"/>
                         <FeatureItem icon="/icon/course/cards.svg" text="اقساطی"/>
                     </div>
                     {status && <StatusBadge status={status}/>}
                 </div>
+                <Image src={image} alt={title} width={500} height={500}
+                       className="object-contain w-[82px] md:w-1/2 h-[82px] md:h-fit"/>
             </div>
         </Link>
     );

--- a/components/organisms/Cards/FeatureCard.tsx
+++ b/components/organisms/Cards/FeatureCard.tsx
@@ -5,7 +5,7 @@ import {Icon} from "@/components/atoms";
 function FeatureCard({icon, title, description}: FeatureType) {
     return (
         <div
-            className="min-w-3/5 h-[104px] md:h-[170px] flex flex-col p-2 md:p-4 md:pb-10 my-2 mx-1 gap-2 bg-white shadow rounded-lg">
+            className="min-w-3/5 flex flex-col p-2 md:p-4 md:pb-10 my-2 mx-1 gap-2 bg-white shadow rounded-lg">
             <div className="flex gap-2 items-center">
                 <Icon src={icon} alt={title} size={40} className="md:w-10 md:h-10"/>
                 <span className="font-medium text-lg text-black">{title}</span>

--- a/components/pages/site/HomePage.tsx
+++ b/components/pages/site/HomePage.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import {HeroSection} from "@/sections/HeroSection";
 import {FeaturesSection} from "@/sections/FeatureSection";
+import CourseSlideSection from "../../../sections/CourseSlideSection/CourseSlideSection";
 
 function HomePage() {
     return (
         <main>
             <HeroSection/>
             <FeaturesSection/>
+            <CourseSlideSection/>
         </main>
     );
 }

--- a/constants/button.ts
+++ b/constants/button.ts
@@ -1,10 +1,12 @@
 export const VARIANTS_STYLE = {
     primary: "bg-[#F28C28] text-white",
     secondary: "bg-[#36A8D9] text-white",
+    primaryOutline: "bg-white border border-[#36A8D9] text-[#36A8D9]",
+    secondaryOutline: ""
 }
 
 export const SIZE_STYLE = {
     small: 'px-3 py-1 text-sm',
     medium: 'w-[120px] h-[35px] px-4 py-1 gap-2 font-semibold text-lg',
-    large: 'w-[205px] h-[45px] px-4 py-2 font-semibold text-[16px]',
+    large: 'w-[205px] h-[45px] px-4 py-2 font-semibold text-[18px] md:text-[16px]',
 }

--- a/data/courses.ts
+++ b/data/courses.ts
@@ -1,4 +1,4 @@
-import {CourseType} from "@/types/hero-section";
+import {CourseType} from "@/types/course";
 
 export const COURSES: CourseType[] = [
     {

--- a/sections/CourseSlideSection/CourseSlideSection.tsx
+++ b/sections/CourseSlideSection/CourseSlideSection.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {Swiper, SwiperSlide} from "swiper/react";
+import {Autoplay} from "swiper/modules";
+import {COURSES} from "@/data/courses";
+import {CourseCard} from "@/components/organisms/Cards";
+import Link from "next/link";
+import {Button} from "@/components/atoms";
+
+function CourseSlideSection() {
+    return (
+        <section className="flex flex-col md:items-center mt-10 md:mt-24">
+            <h2 className="hidden md:flex font-semibold text-[28px] text-center">دوره های مکین</h2>
+
+            <div className="w-full md:mt-12 ">
+                <Swiper
+                    modules={[Autoplay]}
+                    spaceBetween={16} // فاصله بین کارت‌ها
+                    loop={true} // بی‌نهایت
+                    speed={5000} // سرعت اسکرول
+                    autoplay={{
+                        delay: 0, // بدون توقف بین اسلایدها
+                        disableOnInteraction: false,
+                        pauseOnMouseEnter: true,
+                    }}
+                    slidesPerView="auto" // تعداد اسلایدها بر اساس عرض کارت
+                    centeredSlides={true}
+                >
+                    {
+                        COURSES.map(course =>
+                            <SwiperSlide
+                                key={course.id}
+                                style={{width: "264px"}} // عرض ثابت کارت
+                                className="md:!w-[548px]"
+                            >
+                                <CourseCard {...course} variant="slide" className="my-3"/>
+                            </SwiperSlide>
+                        )
+                    }
+                </Swiper>
+            </div>
+
+            <Link href="/courses" className="text-center mt-6">
+                <Button variant="primaryOutline" size="large">
+                    مشاهده همه دوره ها
+                </Button>
+            </Link>
+        </section>
+    );
+}
+
+export default CourseSlideSection;

--- a/sections/CourseSlideSection/index.ts
+++ b/sections/CourseSlideSection/index.ts
@@ -1,0 +1,1 @@
+export {default as CourseSlideSection} from "./CourseSlideSection";

--- a/types/button.ts
+++ b/types/button.ts
@@ -8,6 +8,6 @@ export interface ButtonType {
     isLoading?: boolean;
 }
 
-type Variants = "primary" | "secondary";
+type Variants = "primary" | "secondary" | "primaryOutline" | "secondaryOutline";
 
 type Size = "small" | "medium" | "large";

--- a/types/course.ts
+++ b/types/course.ts
@@ -1,0 +1,12 @@
+type CourseVariant = "hero" | "slide" | "list"
+
+export interface CourseType {
+    id: string;
+    title: string;
+    description: string;
+    status?: "coming_soon" | "open" | "full";
+    image: string;
+    targetDate?: string;
+    variant?: CourseVariant;
+    className?: string;
+}

--- a/types/hero-section.ts
+++ b/types/hero-section.ts
@@ -1,16 +1,3 @@
-type CourseVariant = "hero" | "slide" | "list"
-
-export interface CourseType {
-    id: string;
-    title: string;
-    description: string;
-    status?: "coming_soon" | "open" | "full";
-    image: string;
-    targetDate?: string;
-    variant?: CourseVariant;
-    className?: string;
-}
-
 export interface BannerType {
     id: string;
     imagePath: string;


### PR DESCRIPTION
## Description
This PR introduces a new **CourseSlideSection** component that displays courses
in a horizontal autoplay slider using Swiper.js, along with a dedicated
`CourseCardSlide` variant for slide-specific layout.

### Changes
- Added `CourseSlideSection` component with Swiper configuration for infinite autoplay.
- Created `CourseCardSlide` for slide layout, responsive for mobile and desktop.
- Integrated `FeatureItem` and `StatusBadge` components into course cards.
- Added navigation link to the full courses page.
- Applied consistent spacing and card dimensions.

### Features
- Smooth infinite scrolling with no pause between slides.
- Supports both mobile (`264px`) and desktop (`548px`) card widths.
- Cards are clickable and link to the corresponding course detail page.